### PR TITLE
docs: fix instance connect endpoint

### DIFF
--- a/docs/03-Instance contoller/01-instance-connect.md
+++ b/docs/03-Instance contoller/01-instance-connect.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 | Method | Endpoint                                  |
 | ------ | ----------------------------------------- |
-| GET    | [baseUrl]/instance/connect[instance] |
+| GET    | [baseUrl]/instance/connect/[instance] |
 
 ### Data to be sent in the Request
 


### PR DESCRIPTION
adds a missing / in the docs Instance Connect